### PR TITLE
Add includefile and includefileifexists funcs.

### DIFF
--- a/internal/provider/template.go
+++ b/internal/provider/template.go
@@ -53,15 +53,17 @@ func newTemplate(providerDir, name, text string) (*template.Template, error) {
 	titleCaser := cases.Title(language.Und)
 
 	tmpl.Funcs(map[string]interface{}{
-		"codefile":      codeFile(providerDir),
-		"lower":         strings.ToLower,
-		"plainmarkdown": mdplain.PlainMarkdown,
-		"prefixlines":   tmplfuncs.PrefixLines,
-		"split":         strings.Split,
-		"tffile":        terraformCodeFile(providerDir),
-		"title":         titleCaser.String,
-		"trimspace":     strings.TrimSpace,
-		"upper":         strings.ToUpper,
+		"codefile":            codeFile(providerDir),
+		"lower":               strings.ToLower,
+		"plainmarkdown":       mdplain.PlainMarkdown,
+		"prefixlines":         tmplfuncs.PrefixLines,
+		"split":               strings.Split,
+		"tffile":              terraformCodeFile(providerDir),
+		"title":               titleCaser.String,
+		"trimspace":           strings.TrimSpace,
+		"upper":               strings.ToUpper,
+		"includefile":         tmplfuncs.IncludeFile,
+		"includefileifexists": tmplfuncs.IncludeFileIfExists,
 	})
 
 	var err error

--- a/internal/provider/template.go
+++ b/internal/provider/template.go
@@ -62,7 +62,6 @@ func newTemplate(providerDir, name, text string) (*template.Template, error) {
 		"title":               titleCaser.String,
 		"trimspace":           strings.TrimSpace,
 		"upper":               strings.ToUpper,
-		"includefile":         tmplfuncs.IncludeFile,
 		"includefileifexists": tmplfuncs.IncludeFileIfExists,
 	})
 

--- a/internal/tmplfuncs/tmplfuncs.go
+++ b/internal/tmplfuncs/tmplfuncs.go
@@ -42,3 +42,30 @@ func CodeFile(format, file string) (string, error) {
 
 	return md.String(), nil
 }
+
+func IncludeFile(file string) (string, error) {
+	content, err := os.ReadFile(file)
+	if err != nil {
+		return "", fmt.Errorf("unable to read content from %q: %w", file, err)
+	}
+
+	sContent := strings.TrimSpace(string(content))
+	if sContent == "" {
+		return "", fmt.Errorf("no file content in %q", file)
+	}
+
+	return sContent, nil
+}
+
+func IncludeFileIfExists(file string) (string, error) {
+	content, err := os.ReadFile(file)
+	if err != nil {
+		return "", nil
+	}
+
+	sContent := strings.TrimSpace(string(content))
+	if sContent == "" {
+		return "", fmt.Errorf("no file content in %q", file)
+	}
+	return sContent, nil
+}

--- a/internal/tmplfuncs/tmplfuncs.go
+++ b/internal/tmplfuncs/tmplfuncs.go
@@ -43,20 +43,6 @@ func CodeFile(format, file string) (string, error) {
 	return md.String(), nil
 }
 
-func IncludeFile(file string) (string, error) {
-	content, err := os.ReadFile(file)
-	if err != nil {
-		return "", fmt.Errorf("unable to read content from %q: %w", file, err)
-	}
-
-	sContent := strings.TrimSpace(string(content))
-	if sContent == "" {
-		return "", fmt.Errorf("no file content in %q", file)
-	}
-
-	return sContent, nil
-}
-
 func IncludeFileIfExists(file string) (string, error) {
 	content, err := os.ReadFile(file)
 	if err != nil {


### PR DESCRIPTION
This PR adds two functions:
- `includefile` that includes a file and fails if the file is missing
- `includefileifexists` that includes a files but does not fail if the file is missing

This will allow us to include small text snippets linking to the relevant guides while using the standard template.